### PR TITLE
fix(koishi): enable SC and guard live events

### DIFF
--- a/.changeset/koishi-live-sc-guard-overrides.md
+++ b/.changeset/koishi-live-sc-guard-overrides.md
@@ -1,0 +1,6 @@
+---
+"koishi-plugin-bilibili-notify": patch
+"koishi-plugin-bilibili-notify-advanced-subscription": patch
+---
+
+修复 Koishi 端勾选 SC / 舰长监听后未写入 feature overrides，导致直播插件不监听、不推送的问题。

--- a/koishi/advanced-subscription/src/__tests__/build-advanced-sub.test.ts
+++ b/koishi/advanced-subscription/src/__tests__/build-advanced-sub.test.ts
@@ -60,6 +60,59 @@ function makeRaw(
 }
 
 describe("buildAdvancedSubAndTargets()", () => {
+	it("显式 feature 布尔写入 overrides.features,默认关闭的 SC/舰长勾选后可启用", () => {
+		const raw = makeRaw("11", "111111");
+		raw.liveEnd = false;
+		raw.liveGuardBuy = true;
+		raw.superchat = true;
+		raw.target[0].channelArr[0].liveEnd = false;
+		raw.target[0].channelArr[0].liveGuardBuy = true;
+		raw.target[0].channelArr[0].superchat = true;
+		const cfg: AdvancedSubRawShim = { subs: { "UP-1": raw } };
+
+		const { subs, targets } = buildAdvancedSubAndTargets(
+			cfg as unknown as AdvancedSubRawConfigShape,
+		);
+		const sub = subs[0];
+		const targetId = targets[0].id;
+
+		expect(sub.overrides.features).toMatchObject({
+			liveEnd: false,
+			liveGuardBuy: true,
+			superchat: true,
+		});
+		expect(sub.routing.liveEnd).toEqual([]);
+		expect(sub.routing.liveGuardBuy).toEqual([targetId]);
+		expect(sub.routing.superchat).toEqual([targetId]);
+		expect(sub.overrides.features?.specialDanmaku).toBeUndefined();
+		expect(sub.overrides.features?.specialUserEnter).toBeUndefined();
+	});
+
+	it("channel 级 specialDanmaku/specialUserEnter 只影响 routing,不写入 UP 级 feature overrides", () => {
+		const raw = makeRaw("11", "111111");
+		raw.target[0].channelArr[0].specialDanmaku = true;
+		raw.target[0].channelArr[0].specialUserEnter = true;
+		const rawWithStrayUpSpecial = raw as ReturnType<typeof makeRaw> & {
+			specialDanmaku?: boolean;
+			specialUserEnter?: boolean;
+		};
+		// 即便旧配置/手写配置误带 UP 级 special 布尔,也不能当成 UP feature 或 master gate。
+		rawWithStrayUpSpecial.specialDanmaku = false;
+		rawWithStrayUpSpecial.specialUserEnter = false;
+		const cfg: AdvancedSubRawShim = { subs: { "UP-1": raw } };
+
+		const { subs, targets } = buildAdvancedSubAndTargets(
+			cfg as unknown as AdvancedSubRawConfigShape,
+		);
+		const sub = subs[0];
+		const targetId = targets[0].id;
+
+		expect(sub.routing.specialDanmaku).toEqual([targetId]);
+		expect(sub.routing.specialUserEnter).toEqual([targetId]);
+		expect(sub.overrides.features?.specialDanmaku).toBeUndefined();
+		expect(sub.overrides.features?.specialUserEnter).toBeUndefined();
+	});
+
 	it("emits a target for every channel referenced by routing (Fix 6)", () => {
 		const cfg: AdvancedSubRawShim = {
 			subs: {

--- a/koishi/advanced-subscription/src/convert.ts
+++ b/koishi/advanced-subscription/src/convert.ts
@@ -23,6 +23,17 @@ export { deterministicUuid };
 // ---- Type shapes (kept in lock-step with core.ts schema) ----
 
 type ChannelFeatureKey = FeatureKey;
+type UpFeatureKey = Exclude<FeatureKey, "specialDanmaku" | "specialUserEnter">;
+
+const UP_FEATURE_KEYS: readonly UpFeatureKey[] = [
+	"dynamic",
+	"live",
+	"liveEnd",
+	"liveGuardBuy",
+	"superchat",
+	"wordcloud",
+	"liveSummary",
+] as const;
 
 /**
  * `dynamicAtAll` / `liveAtAll` 不是 FeatureKey,而是 @全体 修饰符。在 advanced-sub Schema 里
@@ -205,9 +216,13 @@ export function rawConfigToSubscription(name: string, raw: SubItemRawConfig): Co
 				const chEnabled = ch[featureKey as keyof typeof ch] as boolean | undefined;
 				if (chEnabled === false) continue;
 
-				// Master-level gating: if the master switch is explicitly false, skip
-				const masterEnabled = raw[featureKey as keyof SubItemRawConfig] as boolean | undefined;
-				if (masterEnabled === false) continue;
+				// Master-level gating only exists for UP-level feature switches. specialDanmaku /
+				// specialUserEnter are channel-level routing toggles backed by customSpecial* user
+				// lists, not UP-level features; do not let stray raw.special* booleans gate them.
+				if ((UP_FEATURE_KEYS as readonly FeatureKey[]).includes(featureKey)) {
+					const masterEnabled = raw[featureKey as keyof SubItemRawConfig] as boolean | undefined;
+					if (masterEnabled === false) continue;
+				}
 
 				if (!routing[featureKey]) routing[featureKey] = [];
 				if (!routing[featureKey].includes(targetId)) {
@@ -230,16 +245,13 @@ export function rawConfigToSubscription(name: string, raw: SubItemRawConfig): Co
 	sub.routing = routing;
 
 	// UP 级 features 总开关 → sub.overrides.features。
-	// 之前 convert.ts 只用 raw.X=false 来 gate routing 计算(routing.X 跳过该 channel),
-	// 但没写到 overrides.features——导致 resolve 后 eff.features.X 仍等于全局默认(全 true),
-	// LiveEngine `needsLiveMonitor` 仍开 WS、payload 仍 build,只是 broadcastToFeature 内
-	// routing 空兜底不发。这跟「features 决定监听」mental model 矛盾。
-	//
-	// 现在显式写 overrides.features:仅在 raw.X === false 时写(true 留空 = 继承全局
-	// 默认 = schema 默认 true)。这样 PR2 接通的 features-only 监听层在 koishi 端真生效。
+	// Koishi 配置里的 feature 是显式二态开关,必须写入 canonical overrides;
+	// 否则 internal 默认关闭的 superchat/liveGuardBuy 即使 UI 勾选 true,也会在
+	// koishi/live 的 resolveFeatures() 中继续回退为 false,导致 RoomSession 监听前短路。
 	const featureOverrides: Partial<Record<FeatureKey, boolean>> = {};
-	for (const k of FEATURE_KEYS) {
-		if (raw[k as keyof SubItemRawConfig] === false) featureOverrides[k] = false;
+	for (const k of UP_FEATURE_KEYS) {
+		const enabled = raw[k as keyof SubItemRawConfig];
+		if (typeof enabled === "boolean") featureOverrides[k] = enabled;
 	}
 	if (Object.keys(featureOverrides).length > 0) {
 		sub.overrides.features = featureOverrides;

--- a/koishi/core/src/__tests__/subscription-loader-upnames.test.ts
+++ b/koishi/core/src/__tests__/subscription-loader-upnames.test.ts
@@ -52,6 +52,28 @@ function makeFlatSub(patch: Partial<FlatSubConfigItem> = {}): FlatSubConfigItem 
 	};
 }
 
+describe("flatSubToSubscription — feature overrides", () => {
+	it("普通配置显式 feature 布尔写入 overrides.features,含默认关闭的 SC/舰长", () => {
+		const registry = makeRegistry();
+		const sub = flatSubToSubscription(
+			makeFlatSub({ superchat: true, liveGuardBuy: true, liveEnd: false }),
+			// biome-ignore lint/suspicious/noExplicitAny: TargetRegistry 测试替身
+			registry as any,
+		);
+
+		expect(sub.overrides.features).toMatchObject({
+			liveEnd: false,
+			liveGuardBuy: true,
+			superchat: true,
+		});
+		expect(sub.routing.liveEnd).toEqual([]);
+		expect(sub.routing.liveGuardBuy).toHaveLength(1);
+		expect(sub.routing.superchat).toHaveLength(1);
+		expect(sub.overrides.features?.specialDanmaku).toBeUndefined();
+		expect(sub.overrides.features?.specialUserEnter).toBeUndefined();
+	});
+});
+
 describe("flatSubToSubscription — 用户手填 UP 昵称写入 Subscription.name", () => {
 	it("普通配置的 name 写入 sub.name,uid 归一化与订阅 id 保持一致", () => {
 		const registry = makeRegistry();

--- a/koishi/core/src/subscription-loader.ts
+++ b/koishi/core/src/subscription-loader.ts
@@ -99,14 +99,18 @@ export function flatSubToSubscription(
 		FEATURE_KEYS.map((k) => [k, [] as string[]]),
 	) as SubscriptionRouting;
 
+	const featureOverrides: Partial<Record<FeatureKey, boolean>> = {};
 	for (const { legacy, feature } of LEGACY_FEATURE_MAP) {
-		if (item[legacy as keyof FlatSubConfigItem]) {
+		const enabled = item[legacy as keyof FlatSubConfigItem];
+		if (typeof enabled === "boolean") featureOverrides[feature] = enabled;
+		if (enabled) {
 			routing[feature] = [...targetIds];
 		}
 	}
 	// specialDanmaku / specialUserEnter get no legacy mapping (not in flat config)
 	// but keep empty arrays as initialized.
 
+	if (Object.keys(featureOverrides).length > 0) sub.overrides.features = featureOverrides;
 	sub.routing = routing;
 	sub.atAllDefaults = {
 		dynamic: item.dynamicAtAll ?? false,

--- a/koishi/live/src/__tests__/sub-view.test.ts
+++ b/koishi/live/src/__tests__/sub-view.test.ts
@@ -91,6 +91,18 @@ describe("storeToSubItemView — per-UP override ?? config 两层折算", () => 
 		expect(view.liveEnd).toBe(DEFAULT_FEATURE_FLAGS.liveEnd);
 	});
 
+	it("默认关闭的直播收入类 feature 可由 per-UP overrides.features 开启", () => {
+		expect(DEFAULT_FEATURE_FLAGS.superchat).toBe(false);
+		expect(DEFAULT_FEATURE_FLAGS.liveGuardBuy).toBe(false);
+
+		const view = storeToSubItemView(
+			makeSub({ features: { superchat: true, liveGuardBuy: true } }),
+			makeConfig(),
+		);
+		expect(view.superchat).toBe(true);
+		expect(view.liveGuardBuy).toBe(true);
+	});
+
 	it("无任何 custom override → 各 customX 块 enable:false", () => {
 		const view = storeToSubItemView(makeSub(), makeConfig());
 		expect(view.customCardStyle).toEqual({ enable: false });


### PR DESCRIPTION
## Summary
- persist explicit Koishi feature switches into subscription overrides
- make SC and guard-buy live events enable default-off feature flags correctly
- keep specialDanmaku/specialUserEnter as channel-level routing toggles

## Tests
- vp test koishi/core/src/__tests__/subscription-loader-upnames.test.ts koishi/advanced-subscription/src/__tests__/build-advanced-sub.test.ts koishi/live/src/__tests__/sub-view.test.ts
- vp run -F koishi-plugin-bilibili-notify typecheck
- vp run -F koishi-plugin-bilibili-notify-advanced-subscription typecheck
- vp run -F koishi-plugin-bilibili-notify-live typecheck
- vp run typecheck
- vp test
- vp run check
- vp run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)