### PR TITLE
fix(standalone): support chat webhook providers

### DIFF
--- a/apps/server/src/__tests__/config-store.test.ts
+++ b/apps/server/src/__tests__/config-store.test.ts
@@ -242,7 +242,7 @@ describe("ConfigStore", () => {
 			name: "wh1",
 			platform: "webhook" as const,
 			enabled: true,
-			config: { url: "https://example.com/hook", headers: {} },
+			config: { url: "https://example.com/hook", provider: "generic" as const, headers: {} },
 		};
 		await store.upsertAdapter(adapter);
 		const target = {

--- a/apps/server/src/config/store.ts
+++ b/apps/server/src/config/store.ts
@@ -303,6 +303,7 @@ function migrateLegacyTargets(raw: unknown[]): {
 					platform: "webhook",
 					config: {
 						url,
+						provider: "generic",
 						secret: cfg.secret || undefined,
 						headers: cfg.headers ?? {},
 					},

--- a/apps/server/src/platforms/__tests__/adapters.test.ts
+++ b/apps/server/src/platforms/__tests__/adapters.test.ts
@@ -13,6 +13,7 @@
  * fetch 用 vi.stubGlobal mock,不打真实网络。
  */
 
+import { createHmac } from "node:crypto";
 import { once } from "node:events";
 import { type AddressInfo, createServer } from "node:net";
 import type {
@@ -66,12 +67,19 @@ async function waitFor(cond: () => boolean | Promise<boolean>, timeoutMs = 3000)
 /** 测试结束要清理的资源(fake server / bot)。afterEach 统一关。 */
 const cleanups: Array<() => void | Promise<void>> = [];
 
-function res(o: { ok: boolean; status?: number; statusText?: string; json?: unknown }) {
+function res(o: {
+	ok: boolean;
+	status?: number;
+	statusText?: string;
+	json?: unknown;
+	text?: string;
+}) {
 	return {
 		ok: o.ok,
 		status: o.status ?? (o.ok ? 200 : 500),
 		statusText: o.statusText ?? "",
 		json: async () => o.json ?? {},
+		text: async () => o.text ?? JSON.stringify(o.json ?? {}),
 	};
 }
 
@@ -1084,6 +1092,14 @@ function whTarget(over: Record<string, unknown> = {}): PushTarget {
 	} as unknown as PushTarget;
 }
 
+function dingTalkSign(secret: string, timestamp: string): string {
+	return createHmac("sha256", secret).update(`${timestamp}\n${secret}`).digest("base64");
+}
+
+function feishuSign(secret: string, timestamp: string): string {
+	return createHmac("sha256", `${timestamp}\n${secret}`).update("").digest("base64");
+}
+
 describe("webhook — send", () => {
 	it("happy:POST JSON body 含元信息 + secret/自定义 header", async () => {
 		fetchMock.mockResolvedValueOnce(res({ ok: true }));
@@ -1103,6 +1119,18 @@ describe("webhook — send", () => {
 			payload: { kind: "text", text: "hello" },
 		});
 		expect(typeof body.ts).toBe("string");
+	});
+
+	it("generic provider 显式配置仍保持旧 envelope 且不解析业务 body", async () => {
+		fetchMock.mockResolvedValueOnce(res({ ok: true, json: { errcode: 310000, errmsg: "bad" } }));
+		const r = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "generic" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(true);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://hook.local");
+		expect(lastBody()).toMatchObject({ payload: { kind: "text", text: "hello" } });
 	});
 
 	it("image/composite payload 序列化为 base64", async () => {
@@ -1134,6 +1162,142 @@ describe("webhook — send", () => {
 		});
 	});
 
+	it("dingtalk:text body + URL 签名 + 业务成功码", async () => {
+		vi.spyOn(Date, "now").mockReturnValue(1_710_000_000_123);
+		fetchMock.mockResolvedValueOnce(res({ ok: true, json: { errcode: 0, errmsg: "ok" } }));
+		const r = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({
+				provider: "dingtalk",
+				url: "https://oapi.dingtalk.com/robot/send?access_token=tok",
+				secret: "SECxxx",
+			}),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(true);
+		const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+		expect(url.searchParams.get("access_token")).toBe("tok");
+		expect(url.searchParams.get("timestamp")).toBe("1710000000123");
+		expect(url.searchParams.get("sign")).toBe(dingTalkSign("SECxxx", "1710000000123"));
+		const init = lastInit() as { headers: Record<string, string> };
+		expect(init.headers["x-bilibili-notify-secret"]).toBeUndefined();
+		expect(lastBody()).toEqual({ msgtype: "text", text: { content: "hello" } });
+	});
+
+	it("dingtalk:HTTP 200 业务失败 / 非 JSON 响应 → ok:false", async () => {
+		fetchMock.mockResolvedValueOnce(
+			res({ ok: true, json: { errcode: 310000, errmsg: "keywords not in content" } }),
+		);
+		const fail = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "dingtalk" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(fail.ok).toBe(false);
+		expect(fail.err).toContain("DingTalk errcode=310000");
+		expect(fail.err).toContain("keywords not in content");
+
+		fetchMock.mockResolvedValueOnce(res({ ok: true, text: "not json" }));
+		const invalid = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "dingtalk" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(invalid).toMatchObject({ ok: false, err: "DingTalk response is not JSON" });
+	});
+
+	it("feishu:text body + body 签名 + 业务成功码", async () => {
+		vi.spyOn(Date, "now").mockReturnValue(1_710_000_000_123);
+		fetchMock.mockResolvedValueOnce(res({ ok: true, json: { code: 0, msg: "success" } }));
+		const r = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({
+				provider: "feishu",
+				url: "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+				secret: "sign-secret",
+			}),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(true);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("https://open.feishu.cn/open-apis/bot/v2/hook/token");
+		const body = lastBody();
+		expect(body).toMatchObject({
+			msg_type: "text",
+			content: { text: "hello" },
+			timestamp: "1710000000",
+		});
+		expect(body.sign).toBe(feishuSign("sign-secret", "1710000000"));
+		const init = lastInit() as { headers: Record<string, string> };
+		expect(init.headers["x-bilibili-notify-secret"]).toBeUndefined();
+	});
+
+	it("feishu:兼容 StatusCode 成功;业务失败 / 非 JSON 响应 → ok:false", async () => {
+		fetchMock.mockResolvedValueOnce(
+			res({ ok: true, json: { StatusCode: 0, StatusMessage: "success" } }),
+		);
+		const ok = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "feishu" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(ok.ok).toBe(true);
+
+		fetchMock.mockResolvedValueOnce(
+			res({ ok: true, json: { code: 19021, msg: "sign match fail" } }),
+		);
+		const fail = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "feishu" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(fail.ok).toBe(false);
+		expect(fail.err).toContain("Feishu code=19021");
+		expect(fail.err).toContain("sign match fail");
+
+		fetchMock.mockResolvedValueOnce(res({ ok: true, text: "not json" }));
+		const invalid = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({ provider: "feishu" }),
+			whTarget(),
+			TEXT,
+		);
+		expect(invalid).toMatchObject({ ok: false, err: "Feishu response is not JSON" });
+	});
+
+	it("platform providers 将 image/composite/forward-images 降级为可读文本", async () => {
+		fetchMock.mockResolvedValue(res({ ok: true, json: { errcode: 0, errmsg: "ok" } }));
+		const ad = createWebhookAdapter({ logger: makeLogger() });
+		await ad.send(whAdapter({ provider: "dingtalk" }), whTarget(), {
+			kind: "image",
+			image: { buffer: Buffer.from("PIC"), mime: "image/png" },
+			caption: "卡片标题",
+		});
+		expect(lastBody()).toEqual({ msgtype: "text", text: { content: "卡片标题" } });
+		await ad.send(whAdapter({ provider: "dingtalk" }), whTarget(), {
+			kind: "composite",
+			segments: [
+				{ type: "text", text: "正文" },
+				{ type: "link", href: "https://example.com", title: "链接" },
+				{ type: "image", buffer: Buffer.from("Q"), mime: "image/jpeg" },
+				{ type: "at-all" },
+			],
+		});
+		expect(lastBody()).toEqual({
+			msgtype: "text",
+			text: { content: "正文\n链接 https://example.com\n[图片]\n@全体成员" },
+		});
+
+		fetchMock.mockResolvedValueOnce(res({ ok: true, json: { code: 0, msg: "success" } }));
+		await ad.send(whAdapter({ provider: "feishu", secret: undefined }), whTarget(), {
+			kind: "forward-images",
+			urls: ["https://i0.hdslb.com/1.jpg", "https://i0.hdslb.com/2.jpg"],
+			forward: false,
+		});
+		expect(lastBody()).toEqual({
+			msg_type: "text",
+			content: { text: "图片:\nhttps://i0.hdslb.com/1.jpg\nhttps://i0.hdslb.com/2.jpg" },
+		});
+	});
+
 	it("非 2xx → ok:false err=HTTP", async () => {
 		fetchMock.mockResolvedValueOnce(res({ ok: false, status: 503, statusText: "Unavailable" }));
 		const r = await createWebhookAdapter({ logger: makeLogger() }).send(
@@ -1144,12 +1308,85 @@ describe("webhook — send", () => {
 		expect(r).toMatchObject({ ok: false, err: "HTTP 503 Unavailable" });
 	});
 
+	it("非 2xx statusText 会脱敏 token/sign/secret", async () => {
+		fetchMock.mockResolvedValueOnce(
+			res({
+				ok: false,
+				status: 403,
+				statusText: "access_token=tok123&sign=sig123 secret=SECxxx",
+			}),
+		);
+		const r = await createWebhookAdapter({ logger: makeLogger() }).send(
+			whAdapter({
+				provider: "dingtalk",
+				url: "https://oapi.dingtalk.com/robot/send?access_token=tok123",
+				secret: "SECxxx",
+			}),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.err).toContain("access_token=***");
+		expect(r.err).toContain("sign=***");
+		expect(r.err).toContain("secret=***");
+		expect(r.err).not.toContain("tok123");
+		expect(r.err).not.toContain("sig123");
+		expect(r.err).not.toContain("SECxxx");
+	});
+
 	it("fetch 抛错 → ok:false + logger.warn", async () => {
 		fetchMock.mockRejectedValueOnce(new Error("network down"));
 		const logger = makeLogger();
 		const r = await createWebhookAdapter({ logger }).send(whAdapter(), whTarget(), TEXT);
 		expect(r).toMatchObject({ ok: false, err: "network down" });
 		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("错误返回和日志会脱敏 webhook secret/token/sign", async () => {
+		const leaked =
+			"request failed url=https://oapi.dingtalk.com/robot/send?access_token=tok123&sign=sig123 secret=SECxxx Authorization=Bearer abcdefghijkl";
+		fetchMock.mockRejectedValueOnce(new Error(leaked));
+		const logger = makeLogger();
+		const r = await createWebhookAdapter({ logger }).send(
+			whAdapter({
+				provider: "dingtalk",
+				url: "https://oapi.dingtalk.com/robot/send?access_token=tok123",
+				secret: "SECxxx",
+			}),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.err).toContain("access_token=***");
+		expect(r.err).toContain("sign=***");
+		expect(r.err).toContain("secret=***");
+		expect(r.err).toContain("Authorization=Bearer ***");
+		expect(r.err).not.toContain("tok123");
+		expect(r.err).not.toContain("sig123");
+		expect(r.err).not.toContain("SECxxx");
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		const logMsg = String(logger.warn.mock.calls[0]?.[0]);
+		expect(logMsg).not.toContain("tok123");
+		expect(logMsg).not.toContain("sig123");
+		expect(logMsg).not.toContain("SECxxx");
+	});
+
+	it("错误返回和日志会脱敏完整 webhook URL path token", async () => {
+		const url = "https://open.feishu.cn/open-apis/bot/v2/hook/path-token-123";
+		fetchMock.mockRejectedValueOnce(new Error(`request to ${url} failed`));
+		const logger = makeLogger();
+		const r = await createWebhookAdapter({ logger }).send(
+			whAdapter({ provider: "feishu", url }),
+			whTarget(),
+			TEXT,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.err).toContain("https://open.feishu.cn/***");
+		expect(r.err).not.toContain(url);
+		expect(r.err).not.toContain("path-token-123");
+		const logMsg = String(logger.warn.mock.calls[0]?.[0]);
+		expect(logMsg).not.toContain(url);
+		expect(logMsg).not.toContain("path-token-123");
 	});
 
 	it("wrong platform → ok:false", async () => {

--- a/apps/server/src/platforms/webhook.ts
+++ b/apps/server/src/platforms/webhook.ts
@@ -1,7 +1,9 @@
+import { createHmac } from "node:crypto";
 import type {
 	DeliveryResult,
 	Logger,
 	NotificationPayload,
+	PayloadSegment,
 	PushAdapter,
 	PushTarget,
 	WebhookAdapterConfig,
@@ -9,11 +11,12 @@ import type {
 import type { PlatformAdapter, ProbeResult } from "./types.js";
 
 /**
- * Webhook adapter — POST the payload as JSON to an arbitrary HTTP endpoint.
+ * Webhook adapter — POST payloads to either the legacy bilibili-notify JSON
+ * endpoint or a supported chat-robot webhook provider.
  *
- * Image buffers are serialized as base64 strings under `payload.image.data`
- * to keep the JSON envelope self-contained. The receiver is expected to
- * understand this shape (NotificationPayload + base64 conversion).
+ * Generic keeps the self-contained JSON envelope (NotificationPayload + base64
+ * conversion). DingTalk / Feishu use their robot text protocols and downgrade
+ * non-text payloads to a readable text summary.
  */
 export interface WebhookAdapterOptions {
 	logger: Logger;
@@ -21,6 +24,15 @@ export interface WebhookAdapterOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 15_000;
+
+type WebhookProvider = "generic" | "dingtalk" | "feishu";
+type WebhookAdapterConfigWithProvider = WebhookAdapterConfig & { provider?: WebhookProvider };
+
+interface WebhookHttpRequest {
+	url: string;
+	headers: Record<string, string>;
+	body: string;
+}
 
 export function createWebhookAdapter(opts: WebhookAdapterOptions): PlatformAdapter {
 	const log = opts.logger;
@@ -31,7 +43,7 @@ export function createWebhookAdapter(opts: WebhookAdapterOptions): PlatformAdapt
 		isAvailable(adapter: PushAdapter, target: PushTarget): boolean {
 			if (adapter.platform !== "webhook" || target.platform !== "webhook") return false;
 			if (!adapter.enabled || !target.enabled) return false;
-			const cfg = adapter.config as WebhookAdapterConfig;
+			const cfg = adapter.config as WebhookAdapterConfigWithProvider;
 			return typeof cfg.url === "string" && cfg.url.length > 0;
 		},
 		async probe(_adapter: PushAdapter): Promise<ProbeResult> {
@@ -54,28 +66,17 @@ export function createWebhookAdapter(opts: WebhookAdapterOptions): PlatformAdapt
 					err: `wrong platform: adapter=${adapter.platform} target=${target.platform}`,
 				};
 			}
-			const cfg = adapter.config as WebhookAdapterConfig;
+			const cfg = adapter.config as WebhookAdapterConfigWithProvider;
+			const provider = webhookProviderOf(cfg);
 			const t0 = Date.now();
 			const ctrl = new AbortController();
 			const timer = setTimeout(() => ctrl.abort(), timeoutMs);
 			try {
-				const headers: Record<string, string> = {
-					"content-type": "application/json",
-					...cfg.headers,
-				};
-				if (cfg.secret) headers["x-bilibili-notify-secret"] = cfg.secret;
-				const body = JSON.stringify({
-					targetId: target.id,
-					targetName: target.name,
-					scope: target.scope,
-					private: !!pushOpts.private,
-					payload: serializePayload(payload),
-					ts: new Date().toISOString(),
-				});
-				const res = await fetch(cfg.url, {
+				const req = buildWebhookRequest(provider, cfg, target, payload, pushOpts);
+				const res = await fetch(req.url, {
 					method: "POST",
-					headers,
-					body,
+					headers: req.headers,
+					body: req.body,
 					signal: ctrl.signal,
 				});
 				const latencyMs = Date.now() - t0;
@@ -83,13 +84,17 @@ export function createWebhookAdapter(opts: WebhookAdapterOptions): PlatformAdapt
 					return {
 						ok: false,
 						latencyMs,
-						err: `HTTP ${res.status} ${res.statusText}`,
+						err: sanitizeWebhookError(`HTTP ${res.status} ${res.statusText}`, cfg),
 					};
 				}
+				const businessErr =
+					provider === "generic" ? null : parseBusinessResponse(provider, await res.text());
+				if (businessErr)
+					return { ok: false, latencyMs, err: sanitizeWebhookError(businessErr, cfg) };
 				return { ok: true, latencyMs };
 			} catch (e) {
 				const latencyMs = Date.now() - t0;
-				const err = e instanceof Error ? e.message : String(e);
+				const err = sanitizeWebhookError(e instanceof Error ? e.message : String(e), cfg);
 				log.warn(`[webhook] target=${target.id} send failed: ${err}`);
 				return { ok: false, latencyMs, err };
 			} finally {
@@ -97,6 +102,249 @@ export function createWebhookAdapter(opts: WebhookAdapterOptions): PlatformAdapt
 			}
 		},
 	};
+}
+
+function webhookProviderOf(cfg: WebhookAdapterConfigWithProvider): WebhookProvider {
+	return cfg.provider ?? "generic";
+}
+
+function buildWebhookRequest(
+	provider: WebhookProvider,
+	cfg: WebhookAdapterConfigWithProvider,
+	target: PushTarget,
+	payload: NotificationPayload,
+	pushOpts: { private?: boolean },
+): WebhookHttpRequest {
+	switch (provider) {
+		case "dingtalk":
+			return buildDingTalkWebhookRequest(cfg, payload);
+		case "feishu":
+			return buildFeishuWebhookRequest(cfg, payload);
+		case "generic":
+			return buildGenericWebhookRequest(cfg, target, payload, pushOpts);
+	}
+}
+
+function baseHeaders(cfg: WebhookAdapterConfigWithProvider): Record<string, string> {
+	return {
+		"content-type": "application/json",
+		...cfg.headers,
+	};
+}
+
+function buildGenericWebhookRequest(
+	cfg: WebhookAdapterConfigWithProvider,
+	target: PushTarget,
+	payload: NotificationPayload,
+	pushOpts: { private?: boolean },
+): WebhookHttpRequest {
+	const headers = baseHeaders(cfg);
+	if (cfg.secret) headers["x-bilibili-notify-secret"] = cfg.secret;
+	return {
+		url: cfg.url,
+		headers,
+		body: JSON.stringify({
+			targetId: target.id,
+			targetName: target.name,
+			scope: target.scope,
+			private: !!pushOpts.private,
+			payload: serializePayload(payload),
+			ts: new Date().toISOString(),
+		}),
+	};
+}
+
+function buildDingTalkWebhookRequest(
+	cfg: WebhookAdapterConfigWithProvider,
+	payload: NotificationPayload,
+): WebhookHttpRequest {
+	const url = cfg.secret ? signDingTalkUrl(cfg.url, cfg.secret) : cfg.url;
+	return {
+		url,
+		headers: baseHeaders(cfg),
+		body: JSON.stringify({
+			msgtype: "text",
+			text: { content: notificationPayloadToRobotText(payload) },
+		}),
+	};
+}
+
+function buildFeishuWebhookRequest(
+	cfg: WebhookAdapterConfigWithProvider,
+	payload: NotificationPayload,
+): WebhookHttpRequest {
+	const body: Record<string, unknown> = {
+		msg_type: "text",
+		content: { text: notificationPayloadToRobotText(payload) },
+	};
+	if (cfg.secret) Object.assign(body, signFeishu(cfg.secret));
+	return {
+		url: cfg.url,
+		headers: baseHeaders(cfg),
+		body: JSON.stringify(body),
+	};
+}
+
+function signDingTalkUrl(rawUrl: string, secret: string, nowMs = Date.now()): string {
+	const timestamp = String(nowMs);
+	const stringToSign = `${timestamp}\n${secret}`;
+	const sign = createHmac("sha256", secret).update(stringToSign).digest("base64");
+	const url = new URL(rawUrl);
+	url.searchParams.set("timestamp", timestamp);
+	url.searchParams.set("sign", sign);
+	return url.toString();
+}
+
+function signFeishu(
+	secret: string,
+	nowSeconds = Math.floor(Date.now() / 1000),
+): {
+	timestamp: string;
+	sign: string;
+} {
+	const timestamp = String(nowSeconds);
+	const stringToSign = `${timestamp}\n${secret}`;
+	return {
+		timestamp,
+		sign: createHmac("sha256", stringToSign).update("").digest("base64"),
+	};
+}
+
+function parseBusinessResponse(
+	provider: Exclude<WebhookProvider, "generic">,
+	text: string,
+): string | null {
+	let body: unknown;
+	try {
+		body = JSON.parse(text);
+	} catch {
+		return `${providerLabel(provider)} response is not JSON`;
+	}
+	if (!isRecord(body)) return `${providerLabel(provider)} response is not an object`;
+	return provider === "dingtalk"
+		? parseDingTalkBusinessResult(body)
+		: parseFeishuBusinessResult(body);
+}
+
+function parseDingTalkBusinessResult(body: Record<string, unknown>): string | null {
+	const errcode = body.errcode;
+	if (isZeroCode(errcode)) return null;
+	const errmsg = stringValue(body.errmsg);
+	const code = codeLabel(errcode);
+	if (code) return `DingTalk errcode=${code}${errmsg ? ` errmsg=${errmsg}` : ""}`;
+	return `DingTalk response missing errcode${errmsg ? ` errmsg=${errmsg}` : ""}`;
+}
+
+function parseFeishuBusinessResult(body: Record<string, unknown>): string | null {
+	const code = firstPresent(body.code, body.StatusCode, body.status_code);
+	if (isZeroCode(code)) return null;
+	const msg = firstString(body.msg, body.message, body.StatusMessage, body.errmsg);
+	const label = codeLabel(code);
+	if (label) return `Feishu code=${label}${msg ? ` msg=${msg}` : ""}`;
+	return `Feishu response missing code${msg ? ` msg=${msg}` : ""}`;
+}
+
+function isZeroCode(value: unknown): boolean {
+	return value === 0 || value === "0";
+}
+
+function codeLabel(value: unknown): string | null {
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	if (typeof value === "string" && value.length > 0) return value;
+	return null;
+}
+
+function providerLabel(provider: Exclude<WebhookProvider, "generic">): string {
+	return provider === "dingtalk" ? "DingTalk" : "Feishu";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function firstPresent(...values: unknown[]): unknown {
+	return values.find((value) => value !== undefined && value !== null);
+}
+
+function firstString(...values: unknown[]): string | null {
+	for (const value of values) {
+		const s = stringValue(value);
+		if (s) return s;
+	}
+	return null;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function sanitizeWebhookError(message: string, cfg: WebhookAdapterConfigWithProvider): string {
+	let out = message
+		.replace(/((?:[?&]|\b)(?:access_token|sign|token|secret|key)=)[^&\s"']+/gi, "$1***")
+		.replace(/\b(Authorization)\b(\s*[:=]\s*Bearer\s+)[^\s",;}]+/gi, "$1$2***")
+		.replace(/\b(x-bilibili-notify-secret)\b(\s*[:=]\s*)[^\s",;}]+/gi, "$1$2***")
+		.replace(/\b(Bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 ***");
+	out = maskConfiguredWebhookUrl(out, cfg.url);
+	if (cfg.secret && cfg.secret.length >= 4) out = out.split(cfg.secret).join("***");
+	return out;
+}
+
+function maskConfiguredWebhookUrl(message: string, rawUrl: string): string {
+	const safeUrl = maskWebhookUrlForError(rawUrl);
+	const variants = new Set<string>([rawUrl]);
+	try {
+		const parsed = new URL(rawUrl);
+		variants.add(parsed.toString());
+		if (parsed.search) {
+			const withoutSearch = new URL(parsed);
+			withoutSearch.search = "";
+			variants.add(withoutSearch.toString());
+		}
+	} catch {
+		// rawUrl already covers invalid legacy values; schema validation prevents new ones.
+	}
+	let out = message;
+	for (const variant of variants) {
+		if (variant.length >= 8) out = out.split(variant).join(safeUrl);
+	}
+	return out;
+}
+
+function maskWebhookUrlForError(rawUrl: string): string {
+	try {
+		const parsed = new URL(rawUrl);
+		return `${parsed.origin}${parsed.pathname ? "/***" : ""}${parsed.search ? "?***" : ""}`;
+	} catch {
+		return "[webhook URL redacted]";
+	}
+}
+
+function notificationPayloadToRobotText(payload: NotificationPayload): string {
+	switch (payload.kind) {
+		case "text":
+			return payload.text;
+		case "image":
+			return payload.caption?.trim() || "[图片]";
+		case "composite": {
+			const text = payload.segments.map(segmentToRobotText).filter(Boolean).join("\n").trim();
+			return text || "[通知]";
+		}
+		case "forward-images":
+			return payload.urls.length > 0 ? `图片:\n${payload.urls.join("\n")}` : "[图片]";
+	}
+}
+
+function segmentToRobotText(segment: PayloadSegment): string {
+	switch (segment.type) {
+		case "text":
+			return segment.text;
+		case "image":
+			return "[图片]";
+		case "link":
+			return segment.title ? `${segment.title} ${segment.href}` : segment.href;
+		case "at-all":
+			return "@全体成员";
+	}
 }
 
 function serializePayload(payload: NotificationPayload): unknown {

--- a/apps/web/src/config/field-labels.ts
+++ b/apps/web/src/config/field-labels.ts
@@ -351,6 +351,11 @@ export const FIELD_LABELS = {
 	"adapter.platform": { label: "平台", section: "adapter" },
 	"adapter.name": { label: "显示名称", section: "adapter" },
 	"adapter.enabled": { label: "启用", section: "adapter" },
+	"config.provider": {
+		label: "Webhook 协议",
+		hint: "Generic 保持旧 JSON envelope；钉钉/飞书按平台机器人协议发送文本消息",
+		section: "transport",
+	},
 	"config.transport": { label: "连接方式", section: "transport" },
 	"config.baseUrl": { label: "HTTP baseUrl", section: "transport" },
 	"config.url": { label: "URL", section: "transport" },

--- a/apps/web/src/pages/Targets.tsx
+++ b/apps/web/src/pages/Targets.tsx
@@ -2,13 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Btn, PlatformIcon, platformLabel, StatusDot, Toggle } from "../components/atoms";
 import { ModalShell } from "../components/dialog";
-import { Field, TInput, TNum } from "../components/forms";
+import { Field, TInput, TNum, TSelect } from "../components/forms";
 import { Icon } from "../components/icons";
 import { ApiError, api } from "../services/api";
 import {
 	KNOWN_PLATFORMS,
 	makeEmptyAdapter,
 	makeEmptyTarget,
+	maskWebhookUrl,
 	type OnebotAdapterConfig,
 	type OnebotSession,
 	type OnebotTransport,
@@ -17,6 +18,11 @@ import {
 	type PushTargetPlatform,
 	type PushTargetScope,
 	switchOnebotTransport,
+	WEBHOOK_PROVIDERS,
+	type WebhookProvider,
+	webhookProviderLabel,
+	webhookSecretHint,
+	webhookUrlPlaceholder,
 } from "../types/domain";
 
 /**
@@ -81,7 +87,11 @@ function adapterEndpointSummary(a: PushAdapter): string {
 		if (c.transport === "ws") return c.url;
 		return `反向 WS :${c.port}`;
 	}
-	if (a.platform === "webhook") return a.config.url;
+	if (a.platform === "webhook") {
+		const provider = a.config.provider ?? "generic";
+		const url = maskWebhookUrl(a.config.url);
+		return provider === "generic" ? url : `${webhookProviderLabel(provider)} · ${url}`;
+	}
 	return "Dashboard 通知中心";
 }
 
@@ -488,17 +498,30 @@ function AdapterConnectionFields({
 	}
 	if (adapter.platform === "webhook") {
 		const cfg = adapter.config;
+		const provider: WebhookProvider = cfg.provider ?? "generic";
 		return (
 			<>
+				<Field
+					label="Webhook 协议"
+					code="config.provider"
+					hint="Generic 保持旧 JSON envelope；钉钉/飞书按平台机器人协议发送文本消息"
+					required
+				>
+					<TSelect<WebhookProvider>
+						value={provider}
+						onChange={(v) => onChange({ ...adapter, config: { ...cfg, provider: v } })}
+						options={[...WEBHOOK_PROVIDERS]}
+					/>
+				</Field>
 				<Field label="URL" code="config.url" required>
 					<TInput
 						value={cfg.url}
 						onChange={(v) => onChange({ ...adapter, config: { ...cfg, url: v } })}
-						placeholder="https://hooks.example.com/bn"
+						placeholder={webhookUrlPlaceholder(provider)}
 						mono
 					/>
 				</Field>
-				<Field label="Secret" code="config.secret" hint="加在 x-bilibili-notify-secret 头">
+				<Field label="Secret" code="config.secret" hint={webhookSecretHint(provider)}>
 					<TInput
 						value={cfg.secret ?? ""}
 						onChange={(v) => onChange({ ...adapter, config: { ...cfg, secret: v || undefined } })}

--- a/apps/web/src/types/domain.conformance.test.ts
+++ b/apps/web/src/types/domain.conformance.test.ts
@@ -23,6 +23,7 @@ import type {
 	PushTarget as CanonPushTarget,
 	ScheduleConfig as CanonScheduleConfig,
 	TemplateBundle as CanonTemplateBundle,
+	WebhookAdapterConfig as CanonWebhookAdapterConfig,
 } from "@bilibili-notify/internal";
 import { describe, it } from "vitest";
 import type {
@@ -33,6 +34,7 @@ import type {
 	PushTarget as MirrorPushTarget,
 	ScheduleFull as MirrorSchedule,
 	TemplateBundleFull as MirrorTemplate,
+	WebhookAdapterConfig as MirrorWebhookAdapterConfig,
 } from "./domain";
 import type { AISettings as MirrorAISettings } from "./globals";
 
@@ -58,6 +60,9 @@ type _Template = Expect<CanonKeysCovered<CanonTemplateBundle, MirrorTemplate>>;
 type _AIOverride = Expect<CanonKeysCovered<CanonAIOverride, MirrorAIOverride>>;
 type _AISettings = Expect<CanonKeysCovered<CanonAISettings, MirrorAISettings>>;
 type _PushTarget = Expect<CanonKeysCovered<CanonPushTarget, MirrorPushTarget>>;
+type _WebhookAdapterConfig = Expect<
+	CanonKeysCovered<CanonWebhookAdapterConfig, MirrorWebhookAdapterConfig>
+>;
 
 // 引用一次,避免 "unused type" 噪音(类型层断言已在上面 tsc 检查时生效)。
 export type _DomainConformance = [
@@ -69,6 +74,7 @@ export type _DomainConformance = [
 	_AIOverride,
 	_AISettings,
 	_PushTarget,
+	_WebhookAdapterConfig,
 ];
 
 describe("types/domain.ts 漂移护栏 (TD1)", () => {

--- a/apps/web/src/types/domain.test.ts
+++ b/apps/web/src/types/domain.test.ts
@@ -9,7 +9,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { newId } from "./domain";
+import {
+	makeEmptyAdapter,
+	maskWebhookUrl,
+	newId,
+	WEBHOOK_PROVIDERS,
+	webhookSecretHint,
+	webhookUrlPlaceholder,
+} from "./domain";
 
 /** RFC 4122 v4:版本位固定 `4`,variant 位固定 `[89ab]`。后端 z.uuid() 等价校验。 */
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -63,5 +70,41 @@ describe("newId", () => {
 		}
 		// 还原后 randomUUID 必须重新可用,确认没污染后续用例。
 		expect(typeof (crypto as { randomUUID?: unknown }).randomUUID).toBe("function");
+	});
+});
+
+describe("webhook adapter factories", () => {
+	it("makeEmptyAdapter(webhook) 默认使用 generic provider 并保留 headers", () => {
+		const adapter = makeEmptyAdapter("webhook", "团队 webhook");
+		expect(adapter.platform).toBe("webhook");
+		if (adapter.platform !== "webhook") return;
+		expect(adapter.config).toMatchObject({
+			provider: "generic",
+			url: "https://example.com/hook",
+			headers: {},
+		});
+	});
+
+	it("WEBHOOK_PROVIDERS 覆盖 generic / dingtalk / feishu", () => {
+		expect(WEBHOOK_PROVIDERS.map((p) => p.value)).toEqual(["generic", "dingtalk", "feishu"]);
+	});
+
+	it("webhook placeholder / secret hint 随 provider 切换", () => {
+		expect(webhookUrlPlaceholder("generic")).toContain("hooks.example.com");
+		expect(webhookSecretHint("generic")).toContain("x-bilibili-notify-secret");
+		expect(webhookUrlPlaceholder("dingtalk")).toContain("oapi.dingtalk.com");
+		expect(webhookSecretHint("dingtalk")).toContain("timestamp/sign");
+		expect(webhookUrlPlaceholder("feishu")).toContain("open.feishu.cn");
+		expect(webhookSecretHint("feishu")).toContain("timestamp/sign");
+	});
+
+	it("maskWebhookUrl 隐藏 query token 与 path token", () => {
+		expect(maskWebhookUrl("https://oapi.dingtalk.com/robot/send?access_token=tok123")).toBe(
+			"https://oapi.dingtalk.com/***?…",
+		);
+		expect(maskWebhookUrl("https://open.feishu.cn/open-apis/bot/v2/hook/token123")).toBe(
+			"https://open.feishu.cn/***",
+		);
+		expect(maskWebhookUrl("not a url")).toBe("已配置 webhook URL");
 	});
 });

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -85,10 +85,58 @@ export type OnebotAdapterConfig =
 
 export type OnebotTransport = OnebotAdapterConfig["transport"];
 
+export type WebhookProvider = "generic" | "dingtalk" | "feishu";
+
 export interface WebhookAdapterConfig {
 	url: string;
+	provider?: WebhookProvider;
 	secret?: string;
 	headers: Record<string, string>;
+}
+
+export const WEBHOOK_PROVIDERS: ReadonlyArray<{ value: WebhookProvider; label: string }> = [
+	{ value: "generic", label: "Generic JSON" },
+	{ value: "dingtalk", label: "钉钉机器人" },
+	{ value: "feishu", label: "飞书机器人" },
+];
+
+export function webhookProviderLabel(provider: WebhookProvider | undefined): string {
+	return (
+		WEBHOOK_PROVIDERS.find((p) => p.value === (provider ?? "generic"))?.label ?? "Generic JSON"
+	);
+}
+
+export function webhookUrlPlaceholder(provider: WebhookProvider | undefined): string {
+	switch (provider ?? "generic") {
+		case "dingtalk":
+			return "https://oapi.dingtalk.com/robot/send?access_token=...";
+		case "feishu":
+			return "https://open.feishu.cn/open-apis/bot/v2/hook/...";
+		case "generic":
+			return "https://hooks.example.com/bn";
+	}
+}
+
+export function webhookSecretHint(provider: WebhookProvider | undefined): string {
+	switch (provider ?? "generic") {
+		case "dingtalk":
+			return "钉钉加签密钥 SEC...；填写后自动追加 timestamp/sign";
+		case "feishu":
+			return "飞书签名密钥；填写后自动在消息体加入 timestamp/sign";
+		case "generic":
+			return "Generic 模式下加在 x-bilibili-notify-secret 头";
+	}
+}
+
+export function maskWebhookUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		const safePath = parsed.pathname === "/" ? "" : "/***";
+		const queryHint = parsed.search ? "?…" : "";
+		return `${parsed.origin}${safePath}${queryHint}`;
+	} catch {
+		return "已配置 webhook URL";
+	}
 }
 
 // no connection-level config (the dashboard itself is the bridge)
@@ -382,7 +430,7 @@ export function makeEmptyAdapter(platform: PushTargetPlatform, name: string): Pu
 		return {
 			...base,
 			platform: "webhook",
-			config: { url: "https://example.com/hook", headers: {} },
+			config: { url: "https://example.com/hook", provider: "generic", headers: {} },
 		};
 	}
 	return {

--- a/packages/internal/src/schema/targets.test.ts
+++ b/packages/internal/src/schema/targets.test.ts
@@ -27,7 +27,7 @@ describe("PushAdapterSchema (discriminated by platform)", () => {
 		expect(r.success).toBe(false);
 	});
 
-	it("accepts a valid webhook adapter", () => {
+	it("accepts a valid webhook adapter and defaults provider to generic", () => {
 		const r = PushAdapterSchema.safeParse({
 			id: UUID_A,
 			name: "wh1",
@@ -36,6 +36,35 @@ describe("PushAdapterSchema (discriminated by platform)", () => {
 			config: { url: "https://example.com/hook" },
 		});
 		expect(r.success).toBe(true);
+		if (r.success && r.data.platform === "webhook") {
+			expect(r.data.config.provider).toBe("generic");
+			expect(r.data.config.headers).toEqual({});
+		}
+	});
+
+	it("accepts supported webhook providers", () => {
+		for (const provider of ["generic", "dingtalk", "feishu"] as const) {
+			const r = PushAdapterSchema.safeParse({
+				id: UUID_A,
+				name: `wh-${provider}`,
+				platform: "webhook",
+				enabled: true,
+				config: { provider, url: "https://example.com/hook", secret: "secret" },
+			});
+			expect(r.success, provider).toBe(true);
+			if (r.success && r.data.platform === "webhook") expect(r.data.config.provider).toBe(provider);
+		}
+	});
+
+	it("rejects unknown webhook provider", () => {
+		const r = PushAdapterSchema.safeParse({
+			id: UUID_A,
+			name: "bad-provider",
+			platform: "webhook",
+			enabled: true,
+			config: { provider: "wechat", url: "https://example.com/hook" },
+		});
+		expect(r.success).toBe(false);
 	});
 
 	it("accepts a valid web-dashboard adapter", () => {
@@ -264,6 +293,19 @@ describe("PushTargetSchema (discriminated by platform)", () => {
 			session: {},
 		});
 		expect(r.success).toBe(true);
+	});
+
+	it("rejects a webhook target with URL-like session keys", () => {
+		const r = PushTargetSchema.safeParse({
+			id: UUID_B,
+			name: "wh:1",
+			adapterId: UUID_A,
+			platform: "webhook",
+			scope: "channel",
+			enabled: true,
+			session: { url: "https://example.com/hook" },
+		});
+		expect(r.success).toBe(false);
 	});
 
 	it("accepts a web-dashboard target with empty session", () => {

--- a/packages/internal/src/schema/targets.ts
+++ b/packages/internal/src/schema/targets.ts
@@ -91,8 +91,13 @@ export const OnebotAdapterConfigSchema = z.union([
 export type OnebotAdapterConfig = z.infer<typeof OnebotAdapterConfigSchema>;
 export type OnebotTransport = OnebotAdapterConfig["transport"];
 
+export const WebhookProviderSchema = z.enum(["generic", "dingtalk", "feishu"]);
+export type WebhookProvider = z.infer<typeof WebhookProviderSchema>;
+
 export const WebhookAdapterConfigSchema = z.object({
 	url: z.url(),
+	/** 协议提供方;旧配置缺省为 generic,保持 bilibili-notify JSON envelope 兼容。 */
+	provider: WebhookProviderSchema.default("generic"),
 	secret: z.string().optional(),
 	/** 自定义 header 例如 Authorization */
 	headers: z.record(z.string(), z.string()).default({}),


### PR DESCRIPTION
## Summary
- add Generic / DingTalk / Feishu webhook provider handling for standalone targets
- send DingTalk and Feishu robot text payloads with provider-specific signing
- parse provider business response codes so real pushes fail loudly
- mask webhook secrets, tokens, signs, and URL path tokens in errors and dashboard summaries

## Audit
- fresh general-purpose audit initially found typecheck and redaction issues
- fixed the findings and ran a second fresh audit: PASS

## Tests
- vp test apps/server/src/platforms/__tests__/adapters.test.ts apps/server/src/__tests__/config-store.test.ts packages/internal/src/schema/targets.test.ts apps/web/src/types/domain.test.ts apps/web/src/types/domain.conformance.test.ts
- vp run typecheck
- vp run check
- vp test
- vp run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)